### PR TITLE
Fix copy artifacts stage and add paid kubernetes option at setup

### DIFF
--- a/configFiles/copyArtifactsJob.yaml
+++ b/configFiles/copyArtifactsJob.yaml
@@ -19,7 +19,7 @@ spec:
           path: /var/run/docker.sock
       containers:
       - name: copyartifacts
-        image: hyperledger/fabric-tools:x86_64-1.0.4
+        image: alpine:3.7
         imagePullPolicy: Always
         command: ["sh", "-c", "ls -l /shared; rm -rf /shared/*; ls -l /shared; while [ ! -d /shared/artifacts ]; do echo Waiting for artifacts to be copied; sleep 2; done; sleep 10; ls -l /shared/artifacts; "]
         volumeMounts:

--- a/configFiles/createVolume-paid.yaml
+++ b/configFiles/createVolume-paid.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "ibmc-file-bronze"
+  name: shared-pvc
+  labels:
+    app: blockchain
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Gi


### PR DESCRIPTION
This commit modifies the copyArtifactsJob.yaml to just use alpine instead of hyperledger/fabric-tools.
Tools in the fabric-tools wasn't really utilized. Alpine only has a size of 2MB instead of 400MB+ for fabric-tools.
This makes pulling the base image easier.

The copyArtifacts stage will now wait for the pod to run before executing `kubectl cp ./artifacts $pod:/shared/`.
Previous script will wait for 5 seconds but sometimes the command `kubectl cp` will result in an error if the pod isn't running yet.

This commit also adds in `--paid` option in setup_blockchainNetwork.sh.
This allows the use of Standard Kubernetes cluster from IBM Cloud. hostPath in createVolume.yaml will not work with a cluster that has multiple nodes.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>