### PR TITLE
Remove all links to IBP ICS pages

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,5 +1,0 @@
-## Acknowledgement
-
-* [IBM Blockchain Platform on IBM Container Service](https://github.com/IBM-Blockchain/ibm-container-service/) - Provides deployment of `ibmblockchain` docker images with default configuration (2 org with one peer each, one CA and one orderer) on IBM Container Service.
-
-Thanks for this, it was helpful to achieve this work.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ Similarily the following code can be used to setup the fabric network.
 
 * [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/en/release-1.1/)
 * [Kubernetes Concepts](https://kubernetes.io/docs/concepts/)
-* [IBM Blockchain Platform on IBM Container Service](https://github.com/IBM-Blockchain/ibm-container-service/)
 
 ## License
 


### PR DESCRIPTION
The IBM Blockchain Platform team is removing the container service scripts and website located at these links:

https://github.com/IBM-Blockchain/ibm-container-service/
http://ibm-blockchain.github.io

This PR removes all references to these links.

I am the lead engineer of the IBM Blockchain Platform developer experience team; please feel free to reach out to me via Slack etc if you want to discuss.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>