### PR TITLE
Update Scripts and README for IKS v1.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 Blockchain is a shared, immutable ledger for recording the history of transactions. The Linux Foundation’s Hyperledger Fabric, the software implementation of blockchain IBM is committed to, is a permissioned network. For developing any blockchain use-case, the very first thing is to have a development environment for Hyperledger Fabric to create and deploy the application. Hyperledger Fabric network can be setup in multiple ways. 
 * [Hyperledger Fabric network On-Premise](http://hyperledger-fabric.readthedocs.io/en/release-1.0/build_network.html)
 * Using [Blockchain as a service](https://console.bluemix.net/catalog/services/blockchain) hosted on [IBM Cloud](https://console.bluemix.net/). IBM Cloud provides you Blockchain as a service with a Starter Membership Plan and Enterprise Membership Plan.
-* Hyperledger Fabric network using [Kubernetes APIs]((https://console.bluemix.net/containers-kubernetes/catalog/cluster)) on [IBM Cloud Container Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster)
+* Hyperledger Fabric network using [Kubernetes APIs]((https://console.bluemix.net/containers-kubernetes/catalog/cluster)) on [IBM Cloud Kubernetes Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster)
 
-This code pattern demonstrates the steps involved in setting up your business network on **Hyperledger Fabric using Kubernetes APIs on IBM Cloud Container Service**. 
+This code pattern demonstrates the steps involved in setting up your business network on **Hyperledger Fabric using Kubernetes APIs on IBM Cloud Kubernetes Service**.
 
 Hosting the Hyperledger Fabric network on IBM Cloud provides you many benefits like multiple users can work on the same setup, the setup can be used for different blockchain applications, the setup can be reused and so on. Please note that the blockchain network setup on Kubernetes is good to use for demo scenarios but for production, it is recommended to use IBM Blockchain as a service hosted on IBM Cloud.
 
 #### Kubernetes Cluster
 
-[IBM Cloud Container Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster) allows you to create a free cluster that comes with 2 CPUs, 4 GB memory, and 1 worker node. It allows you to get familiar with and test Kubernetes capabilities. However they lack capabilities like persistent NFS file-based storage with volumes.
+[IBM Cloud Kubernetes Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster) allows you to create a free cluster that comes with 2 CPUs, 4 GB memory, and 1 worker node. It allows you to get familiar with and test Kubernetes capabilities. However they lack capabilities like persistent NFS file-based storage with volumes.
 
 To setup your cluster for maximum availability and capacity, IBM Cloud allows you to create a fully customizable, production-ready cluster called _standard cluster_. _Standard clusters_ allow highly available cluster configurations such as a setup with two clusters that run in different regions, each with multiple worker nodes. Please see https://console.bluemix.net/docs/containers/cs_planning.html#cs_planning_cluster_config to review other options for highly available cluster configurations.
 
@@ -30,7 +30,7 @@ When the reader has completed this pattern, they will understand how to:
 
   ![](images/architecture.png)
 
-1. Log in to IBM Cloud CLI and initialize IBM Cloud Container Service plugin.
+1. Log in to IBM Cloud CLI and initialize IBM Cloud Kubernetes Service plugin.
 2. Set context for Kubernetes cluster using CLI and download Kubernetes configuration files. After downloading configuration files, set KUBECONFIG environment variable.
 3. Run script to deploy your hyperledger fabric network on Kubernetes cluster.
 4. Access Kubernetes dashboard.
@@ -39,7 +39,7 @@ When the reader has completed this pattern, they will understand how to:
 
 * [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/): Hyperledger Fabric is a platform for distributed ledger solutions underpinned by a modular architecture delivering high degrees of confidentiality, resiliency, flexibility and scalability.
 
-* [IBM Cloud Container Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster): IBM Container Service enables the orchestration of intelligent scheduling, self-healing, and horizontal scaling.
+* [IBM Cloud Kubernetes Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster): IBM Kubernetes Service enables the orchestration of intelligent scheduling, self-healing, and horizontal scaling.
 
 ## Featured technologies
 
@@ -72,7 +72,7 @@ Follow these steps to setup and run this code pattern.
 
 ### 1. Create a Kubernetes Cluster on IBM Cloud
 
-* Create a Kubernetes cluster with [IBM Cloud Container Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster) using GUI. This pattern uses the _free cluster_.
+* Create a Kubernetes cluster with [IBM Cloud Kubernetes Service](https://console.bluemix.net/containers-kubernetes/catalog/cluster) using GUI. This pattern uses the _free cluster_.
 
   ![](images/create-service.png)
   
@@ -85,7 +85,7 @@ Follow these steps to setup and run this code pattern.
 
 * Install [Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/). The prefix for running commands by using the Kubernetes CLI is `kubectl`.
 
-* Install the container service plugin using the following command.
+* Install the kubernetes service plugin using the following command.
   ```
   bx plugin install container-service -r Bluemix
   ```
@@ -141,6 +141,19 @@ In the source directory,
 
 If there is any change in network topology, need to modify the configuration files (.yaml files) appropriately. The configuration files are located in `artifacts` and `configFiles` directory. For example, if you decide to increase/decrease the capacity of persistant volume then you need to modify `createVolume.yaml`.  
 
+If the Kubernetes' Server version is **v1.11.x** or above, the cluster may be using `containerd` as its container runtime therefore using `docker.sock` of the worker node is not possible. You could deploy and use a Docker daemon in a container.
+> In IKS v1.11.x and above, it is using `containerd`
+
+Modify the `configFiles/peersDeployment.yaml` file to point to a Docker service. Change instances of `unix:///host/var/run/docker.sock` to `tcp://docker:2375` with a text editor or use the commands below.
+
+```
+## macOS
+$ sed -i '' s#unix:///host/var/run/docker.sock#tcp://docker:2375# configFiles/peersDeployment.yaml
+
+## Linux
+$ sed -i s#unix:///host/var/run/docker.sock#tcp://docker:2375# configFiles/peersDeployment.yaml
+```
+
 #### Run the script to deploy your Hyperledger Fabric Network
 
 Once you have completed the changes (if any) in configuration files, you are ready to deploy your network. Execute the script to deploy your hyperledger fabric network.
@@ -149,6 +162,8 @@ Once you have completed the changes (if any) in configuration files, you are rea
   $ chmod +x setup_blockchainNetwork.sh
   $ ./setup_blockchainNetwork.sh
   ```
+
+  > If you are using a Standard IKS cluster with multiple workers nodes, do `./setup_blockchainNetwork.sh --paid` so that the shared volume of the blockchain containers would work properly.
 
 Note: Before running the script, please check your environment. You should able to run `kubectl commands` properly with your cluster as explained in step 3. 
 

--- a/configFiles/createVolume-paid.yaml
+++ b/configFiles/createVolume-paid.yaml
@@ -1,8 +1,6 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "ibmc-file-bronze"
   name: shared-pvc
   labels:
     app: blockchain
@@ -11,4 +9,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 4Gi
+      storage: 20Gi
+  storageClassName: "ibmc-file-bronze"

--- a/configFiles/docker-volume.yaml
+++ b/configFiles/docker-volume.yaml
@@ -2,30 +2,30 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: shared-pv
+  name: docker-pv
   labels:
     type: local
-    name: sharedvolume
+    name: dockervolume
 spec:
   capacity:
-    storage: 1Gi
+    storage: 10Gi
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/tmp"
+    path: "/tmp-docker-pv"
 
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: shared-pvc
+  name: docker-pvc
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi
   storageClassName: ""
   selector:
     matchLabels:
-      name: sharedvolume
+      name: dockervolume

--- a/configFiles/docker.yaml
+++ b/configFiles/docker.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker
+  labels:
+    run: docker
+spec:
+  selector:
+    name: docker
+  ports:
+  - protocol: TCP
+    targetPort: 2375
+    port: 2375
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: docker-dind
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: docker
+    spec:
+      volumes:
+      - name: dockervolume
+        persistentVolumeClaim:
+          claimName: docker-pvc
+      containers:
+      - name: docker
+        securityContext:
+          privileged: true
+        image: "docker:stable-dind"
+        ports:
+        - containerPort: 2375
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: dockervolume

--- a/deleteNetwork.sh
+++ b/deleteNetwork.sh
@@ -7,6 +7,8 @@ kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 kubectl delete -f ${KUBECONFIG_FOLDER}/join_channel.yaml
 kubectl delete -f ${KUBECONFIG_FOLDER}/create_channel.yaml
 
+kubectl delete --ignore-not-found=true -f ${KUBECONFIG_FOLDER}/docker.yaml
+
 kubectl delete -f ${KUBECONFIG_FOLDER}/peersDeployment.yaml
 kubectl delete -f ${KUBECONFIG_FOLDER}/blockchain-services.yaml
 
@@ -14,6 +16,7 @@ kubectl delete -f ${KUBECONFIG_FOLDER}/generateArtifactsJob.yaml
 kubectl delete -f ${KUBECONFIG_FOLDER}/copyArtifactsJob.yaml
 
 kubectl delete -f ${KUBECONFIG_FOLDER}/createVolume.yaml
+kubectl delete --ignore-not-found=true -f ${KUBECONFIG_FOLDER}/docker-volume.yaml
 
 sleep 15
 

--- a/setup_blockchainNetwork.sh
+++ b/setup_blockchainNetwork.sh
@@ -7,6 +7,27 @@ else
     exit
 fi
 
+# Create Docker deployment
+if [ "$(cat configFiles/peersDeployment.yaml | grep -c tcp://docker:2375)" != "0" ]; then
+    echo "peersDeployment.yaml file was configured to use Docker in a container."
+    echo "Creating Docker deployment"
+
+    kubectl create -f ${KUBECONFIG_FOLDER}/docker-volume.yaml
+    kubectl create -f ${KUBECONFIG_FOLDER}/docker.yaml
+    sleep 5
+
+    dockerPodStatus=$(kubectl get pods --selector=name=docker --output=jsonpath={.items..phase})
+
+    while [ "${dockerPodStatus}" != "Running" ]; do
+        echo "Wating for Docker container to run. Current status of Docker is ${dockerPodStatus}"
+        sleep 5;
+        if [ "${dockerPodStatus}" == "Error" ]; then
+            echo "There is an error in the Docker pod. Please check logs."
+            exit 1
+        fi
+        dockerPodStatus=$(kubectl get pods --selector=name=docker --output=jsonpath={.items..phase})
+    done
+fi
 
 # Creating Persistant Volume
 echo -e "\nCreating volume"


### PR DESCRIPTION
This commit modifies the scripts to use a Docker daemon in a container
instead of using `docker.sock` of a worker node. This change is needed
since IKS v1.11 onwards will now use `containerd` as its container
runtime and docker.sock will no longer be present in the worker nodes.

This commit also modifies the README to mention if the user is using a
version of v1.11, they will need to modify the kubernetes configuration
yaml file. This commit also mentions the use of `--paid` argument so
that the user could properly set up shared volumes with dynamic
provisioning. If the user has a standard cluster with multiple worker
nodes, `hostPath` in the persistent volume will not properly work.

Additional yaml files are for the Docker daemon deployment and service.
This will be used by the chaincode containers.

`createVolume-paid.yaml` is modified so that it would use the new spec
`storageClassName` instead of the annotation which will be
deprecated in the future versions of kubernetes.


Fixes #27 
Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>